### PR TITLE
Less plugins passed in via options are no longer ignored

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,8 @@ const rollupPostcssLessLoader = options => {
               pluginManager.addFileManager(rollupFileManager);
             },
             minVersion: [2, 1, 1]
-          }
+          },
+          ...(this.options.plugins || [])
         ]
       });
 

--- a/test/resources/a-file-that-references-plugin.less
+++ b/test/resources/a-file-that-references-plugin.less
@@ -1,0 +1,3 @@
+.test {
+    content: foo();
+}

--- a/test/resources/expected/a-file-that-references-node-modules.css
+++ b/test/resources/expected/a-file-that-references-node-modules.css
@@ -1,0 +1,6 @@
+.my-class {
+  color: red;
+}
+.my-other-class {
+  color: blue;
+}

--- a/test/resources/expected/a-file-that-references-plugin.css
+++ b/test/resources/expected/a-file-that-references-plugin.css
@@ -1,0 +1,3 @@
+.test {
+  content: "bar";
+}

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -1,0 +1,60 @@
+const path = require('path');
+const lessLoader = require('../../lib/index');
+const fs = require('fs');
+
+const mockPlugin = {
+  install(less, pluginManager, functions) {
+    functions.add('foo', () => '"bar"');
+  }
+};
+
+test('test that plugin compiles a file as expected', () => {
+  const code = fs.readFileSync('test/resources/a-file-that-references-node-modules.less').toString();
+  const expectedCode = fs.readFileSync('test/resources/expected/a-file-that-references-node-modules.css').toString();
+  const mockContext = {
+    options: {},
+    sourceMap: true,
+    dependencies: new Set()
+  };
+  const { process: processLess } = lessLoader({ nodeModulePath: 'test/resources/mock_node_modules', aliases: {} });
+
+  return processLess.call(mockContext, { code }).then(result => {
+    expect(result.code).toEqual(expectedCode);
+    expect(result.map).toBeDefined();
+  });
+});
+
+test('test that imports are added to dependencies', () => {
+  const code = fs.readFileSync('test/resources/a-file-that-references-node-modules.less').toString();
+
+  const mockContext = {
+    options: {},
+    dependencies: new Set()
+  };
+
+  const { process: processLess } = lessLoader({ nodeModulePath: 'test/resources/mock_node_modules', aliases: {} });
+
+  return processLess.call(mockContext, { code }).then(() => {
+    expect(mockContext.dependencies).toEqual(
+      new Set([
+        'test/resources/mock_node_modules/some-dir/somefile.less',
+        'test/resources/mock_node_modules/a-different-dir/someFile.less'
+      ])
+    );
+  });
+});
+
+test('test that plugins passed in via options are included when compiling', () => {
+  const code = fs.readFileSync('test/resources/a-file-that-references-plugin.less').toString();
+  const expectedCode = fs.readFileSync('test/resources/expected/a-file-that-references-plugin.css').toString();
+
+  const mockContext = {
+    options: {
+      plugins: [mockPlugin]
+    }
+  };
+
+  const { process: processLess } = lessLoader({ nodeModulePath: 'mock_node_modules', aliases: {} });
+
+  return processLess.call(mockContext, { code }).then(result => expect(result.code).toEqual(expectedCode));
+});


### PR DESCRIPTION
When initializing the postcss plugin, LESS plugins passed in were clobbered by the plugins declaration adding the `rollupFileManager`.


```js
// rollup.config.js
postcss({
    use: { less: { plugins: [myPlugin] } }, // previously ignored
    loaders: [
        rollupPostcssLessLoader({
            nodeModulePath: NODE_MODULE_PATH,
            aliases: { ... }
        })
    ]
}),
```

Added test coverage for index.js and the issue in question